### PR TITLE
chore(db): supabase lint fixes + prune helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,189 +1,74 @@
-# Byte-compiled / optimized / DLL files
+# Python
 __pycache__/
 *.py[cod]
-*$py.class
-
-# C extensions
-*.so
-
-# Distribution / packaging
 .Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-pip-wheel-metadata/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-.hypothesis/
-.pytest_cache/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-.python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don’t work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# celery beat schedule file
-celerybeat-schedule
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.venv
-env/
+*.so
+.venv/
 venv/
 ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
-
-# Azure Functions artifacts
-bin
-obj
-appsettings.json
-local.settings.json
-
-# Azurite artifacts
-__blobstorage__
-__queuestorage__
-__azurite_db*__.json
-.python_packages
-
-# FC runtime / audit artifacts (do not commit)
-**/outputs/
-**/logs/
-**/exports/
-**/data/
-**/tmp/
-**/.cache/
-**/__pycache__/
-**/*.pyc
-**/.pytest_cache/
-**/.venv/
-**/venv/
-
-# Evidence attachments
-**/attachments/
-**/sent_eml/
-**/filled_*/
-**/*.eml
-**/*.msg
-
-# Databases and dumps
-**/*.db
-**/*.sqlite
-**/*.sqlite3
-
-# Audit bundles / large files
-**/*.zip
-**/*.7z
-
-# Secrets / env
-**/.env
-**/.env.*
-**/*secrets*
-**/*token*
+.env
+.env.local
+.env.*
 !.env.exemplo
 !apps/APP/.env.exemplo
 
-# Node / frontend
-**/node_modules/
-**/dist/
-**/build/
-**/.next/
-**/.turbo/
-**/.vite/
+# Node
+node_modules/
+.pnpm-debug.log*
+npm-debug.log*
 
-# IDE / editors
-**/.vscode/
-**/.idea/
-**/.cursor/
+# IDE
+.vscode/
+.idea/
 *.swp
 *.swo
 .cursorignore
 .cursorindexingignore
+*.code-workspace
+
+# Build / Dist
+build/
+dist/
+*.egg-info/
+
+# Logs e Temporários
+logs/
+outputs/
+temp/
+*.log
+*.tmp
+*.bak
+*.backup
+_archive/
+_archives/
+
+# Dados e Arquivos Grandes
+*.zip
+*.rar
+*.7z
+*.tar.gz
+*.sqlite
+*.db
+*.csv
+*.xlsx
+*.xls
+*.json
+*.txt
+*.md
+!README.md
+!docs/**/*.md
+!fc_core/data/reference/clientes.json
+
+# Pastas de Lixo Específicas Detectadas
+backups/
+apps/dev/extracted_*
+projeto_instagram_congelado/
+_outros_scripts/
+extracted_data/
+pastes/
+temp_*/
+sigejup-extracted/
+legacy_workspaces/
+
+# Docker
+docker/*/data/

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-propulsor.app.br
+www.propulsor.app.br

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+propulsor.app.br

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-www.propulsor.app.br
+fusione.app.br

--- a/apps/APP/sql/20260219_001_supabase_lint_fixes.sql
+++ b/apps/APP/sql/20260219_001_supabase_lint_fixes.sql
@@ -1,0 +1,129 @@
+-- 20260219_001_supabase_lint_fixes.sql
+-- Purpose:
+-- 1) Remove duplicate index/constraint on public.db_requisicoes when redundant.
+-- 2) Fix mutable search_path on:
+--    - public.set_webhook_events_updated_at(...)
+--    - public.fc_touch_updated_at(...)
+--
+-- Notes:
+-- - Idempotent by design.
+-- - Keeps PRIMARY KEY intact.
+-- - Uses pg_catalog, public as the minimum safe search_path.
+
+-- Optional diagnostic query (before/after):
+-- select schemaname, tablename, indexname, indexdef
+-- from pg_indexes
+-- where schemaname='public'
+--   and tablename='db_requisicoes'
+--   and indexname in ('db_requisicoes_pkey','ux_db_requisicoes_id');
+
+DO $$
+DECLARE
+  idx_oid oid;
+  idx_constraint_name text;
+  idx_constraint_type "char";
+BEGIN
+  IF to_regclass('public.db_requisicoes') IS NULL THEN
+    RAISE NOTICE 'Table public.db_requisicoes not found. Skipping duplicate index fix.';
+    RETURN;
+  END IF;
+
+  SELECT c.oid
+    INTO idx_oid
+  FROM pg_class c
+  JOIN pg_namespace n
+    ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname = 'ux_db_requisicoes_id'
+    AND c.relkind = 'i'
+  LIMIT 1;
+
+  IF idx_oid IS NULL THEN
+    RAISE NOTICE 'Index public.ux_db_requisicoes_id not found. Nothing to drop.';
+    RETURN;
+  END IF;
+
+  SELECT conname, contype
+    INTO idx_constraint_name, idx_constraint_type
+  FROM pg_constraint
+  WHERE conindid = idx_oid
+    AND conrelid = 'public.db_requisicoes'::regclass
+  LIMIT 1;
+
+  IF idx_constraint_name IS NULL THEN
+    EXECUTE 'DROP INDEX IF EXISTS public.ux_db_requisicoes_id';
+    RAISE NOTICE 'Dropped index public.ux_db_requisicoes_id.';
+  ELSIF idx_constraint_type = 'p' THEN
+    RAISE NOTICE 'Index public.ux_db_requisicoes_id backs PRIMARY KEY constraint %, skipping.', idx_constraint_name;
+  ELSE
+    EXECUTE format(
+      'ALTER TABLE public.db_requisicoes DROP CONSTRAINT IF EXISTS %I',
+      idx_constraint_name
+    );
+    RAISE NOTICE 'Dropped constraint % backed by ux_db_requisicoes_id.', idx_constraint_name;
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  fn regprocedure;
+  fn_count integer := 0;
+BEGIN
+  FOR fn IN
+    SELECT p.oid::regprocedure
+    FROM pg_proc p
+    JOIN pg_namespace n
+      ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'set_webhook_events_updated_at'
+  LOOP
+    EXECUTE format(
+      'ALTER FUNCTION %s SET search_path = pg_catalog, public',
+      fn
+    );
+    fn_count := fn_count + 1;
+  END LOOP;
+
+  IF fn_count = 0 THEN
+    RAISE NOTICE 'Function public.set_webhook_events_updated_at(...) not found. Skipping.';
+  ELSE
+    RAISE NOTICE 'Updated search_path for % function(s): set_webhook_events_updated_at.', fn_count;
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  fn regprocedure;
+  fn_count integer := 0;
+BEGIN
+  FOR fn IN
+    SELECT p.oid::regprocedure
+    FROM pg_proc p
+    JOIN pg_namespace n
+      ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'fc_touch_updated_at'
+  LOOP
+    EXECUTE format(
+      'ALTER FUNCTION %s SET search_path = pg_catalog, public',
+      fn
+    );
+    fn_count := fn_count + 1;
+  END LOOP;
+
+  IF fn_count = 0 THEN
+    RAISE NOTICE 'Function public.fc_touch_updated_at(...) not found. Skipping.';
+  ELSE
+    RAISE NOTICE 'Updated search_path for % function(s): fc_touch_updated_at.', fn_count;
+  END IF;
+END $$;
+
+-- Optional diagnostic query (after):
+-- select n.nspname as schema_name,
+--        p.proname as function_name,
+--        pg_get_function_identity_arguments(p.oid) as args,
+--        p.proconfig
+-- from pg_proc p
+-- join pg_namespace n on n.oid = p.pronamespace
+-- where n.nspname = 'public'
+--   and p.proname in ('set_webhook_events_updated_at', 'fc_touch_updated_at');

--- a/tools/fc_prune_remote_branches.ps1
+++ b/tools/fc_prune_remote_branches.ps1
@@ -1,0 +1,303 @@
+param(
+  [Parameter(Mandatory=$true)]
+  [string]$RepoPath,
+
+  # ex: ggrighi15/fusione_dev
+  [Parameter(Mandatory=$true)]
+  [string]$RepoSlug,
+
+  [string]$Remote = "origin",
+
+  # Bases para checar se o branch foi absorvido
+  [string[]]$BaseBranches = @("main","develop"),
+
+  # Padroes de inclusao (se -Branches nao for informado)
+  [string[]]$IncludePatterns = @("feat/*","hotfix/*"),
+
+  # Branches a nunca deletar
+  [string[]]$ExcludeBranches = @("main","develop"),
+
+  # Lista explicita de branches (sem prefixo origin/)
+  [string[]]$Branches = @(),
+
+  # Se true, permite delecao quando houver PR merged na base (compativel com squash merge)
+  [switch]$AllowMergedPR,
+
+  [switch]$DryRun,
+  [switch]$Apply,
+
+  # Se nao der pra checar PR (sem gh) ou se nao for ancestor/mergedPR, ainda assim permite deletar
+  [switch]$Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+try { chcp 65001 | Out-Null } catch {}
+try { [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false) } catch {}
+
+function Info($m){ Write-Host "[INFO] $m" }
+function Warn($m){ Write-Host "[WARN] $m" -ForegroundColor Yellow }
+function Err ($m){ Write-Host "[ERR ] $m" -ForegroundColor Red }
+
+if (-not $DryRun -and -not $Apply) { $DryRun = $true }
+if ($DryRun -and $Apply) { throw "Use apenas um: -DryRun OU -Apply" }
+
+if (-not (Test-Path $RepoPath)) { throw "RepoPath nao existe: $RepoPath" }
+if (-not (Test-Path (Join-Path $RepoPath ".git"))) { throw "Nao e um repo git: $RepoPath" }
+
+# Normaliza Branches quando vier como string unica com virgulas: "a,b,c"
+if ($Branches -and $Branches.Count -eq 1 -and ($Branches[0] -match ",")) {
+  $Branches = $Branches[0].Split(",") | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+}
+
+# Verifica gh
+$gh = Get-Command gh -ErrorAction SilentlyContinue
+$hasGh = [bool]$gh
+
+# Diretorio de relatorio
+$stamp = (Get-Date -Format "yyyyMMdd_HHmmss")
+$reportDir = "C:\Aggregatto\outputs\remote_prune_$stamp"
+New-Item -ItemType Directory -Path $reportDir -Force | Out-Null
+$csvPath = Join-Path $reportDir "remote_branch_prune_plan.csv"
+$mdPath  = Join-Path $reportDir "remote_branch_prune_plan.md"
+
+Info "Repo: $RepoSlug"
+Info "RepoPath: $RepoPath"
+Info ("Mode: " + ($(if($Apply){"APPLY"} else {"DRYRUN"})))
+Info ("AllowMergedPR(squash): " + $AllowMergedPR.IsPresent)
+Info "ReportDir: $reportDir"
+
+# Atualiza refs
+Info "Fetching remotes..."
+git -C $RepoPath fetch --all --prune | Out-Null
+
+# Lista branches remotos origin/*
+$refs = git -C $RepoPath for-each-ref "refs/remotes/$Remote" --format="%(refname:short)" |
+  ForEach-Object { $_.Trim() } | Where-Object { $_ }
+
+# Normaliza: origin/xyz -> xyz
+$remoteBranches = $refs | ForEach-Object {
+  if ($_ -like "$Remote/*") { $_.Substring($Remote.Length+1) } else { $_ }
+} | Where-Object { $_ -and ($_ -ne "HEAD") }
+
+# Selecao inicial
+$candidates = @()
+if ($Branches -and $Branches.Count -gt 0) {
+  $candidates = $remoteBranches | Where-Object { $Branches -contains $_ }
+} else {
+  foreach ($b in $remoteBranches) {
+    foreach ($p in $IncludePatterns) {
+      if ($b -like $p) { $candidates += $b; break }
+    }
+  }
+  $candidates = $candidates | Sort-Object -Unique
+}
+
+# Exclui protegidos
+$candidates = $candidates | Where-Object { $ExcludeBranches -notcontains $_ }
+
+if (-not $candidates -or $candidates.Count -eq 0) {
+  Warn "Nenhum branch candidato encontrado."
+  "# Plano de limpeza (vazio)`n`nNenhum branch candidato encontrado." | Set-Content -LiteralPath $mdPath -Encoding UTF8
+  Info "Report: $mdPath"
+  exit 0
+}
+
+# Helper: PR aberto?
+function Get-HasOpenPR([string]$branch){
+  if (-not $hasGh) { return $null }
+  try {
+    $json = gh pr list --repo $RepoSlug --state open --head $branch --json number,baseRefName 2>$null
+    if (-not $json) { return $false }
+    $raw = $json.Trim()
+    if ($raw -eq "[]") { return $false }
+    $items = New-Object System.Collections.Generic.List[object]
+    ($json | ConvertFrom-Json) | ForEach-Object {
+      if ($null -ne $_) { $items.Add($_) | Out-Null }
+    }
+    return ($items.Count -gt 0)
+  } catch {
+    return $null
+  }
+}
+
+# Helper: branch e ancestor de alguma base?
+function Get-IsAncestorMerged([string]$branch){
+  foreach ($base in $BaseBranches) {
+    $rb = "$Remote/$branch"
+    $bb = "$Remote/$base"
+    git -C $RepoPath merge-base --is-ancestor $rb $bb 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) { return $true }
+  }
+  return $false
+}
+
+# Helper: obter PR merged (compativel com squash) e validar mergeCommit esta contido na base
+function Get-MergedPRProof([string]$branch){
+  if (-not $hasGh) { return $null }
+
+  try {
+    $json = gh pr list --repo $RepoSlug --state merged --head $branch --json number,baseRefName,mergedAt,mergeCommit 2>$null
+    if (-not $json) { return $null }
+    $raw = $json.Trim()
+    if ($raw -eq "[]") { return $null }
+
+    $prs = New-Object System.Collections.Generic.List[object]
+    ($json | ConvertFrom-Json) | ForEach-Object {
+      if ($null -ne $_) { $prs.Add($_) | Out-Null }
+    }
+    if ($prs.Count -eq 0) { return $null }
+
+    # filtra bases alvo
+    $filtered = New-Object System.Collections.Generic.List[object]
+    foreach ($item in $prs) {
+      if ($BaseBranches -contains $item.baseRefName) {
+        $filtered.Add($item) | Out-Null
+      }
+    }
+    if ($filtered.Count -eq 0) { return $null }
+
+    # ordena pelo mergedAt desc
+    $sorted = $filtered | Sort-Object -Property mergedAt -Descending
+
+    foreach ($pr in $sorted) {
+      $base = $pr.baseRefName
+      $oid = $null
+      if ($pr.mergeCommit -and $pr.mergeCommit.oid) { $oid = $pr.mergeCommit.oid }
+
+      if (-not $oid) { continue }
+
+      # valida que o mergeCommit esta contido na base remota
+      $bb = "$Remote/$base"
+      git -C $RepoPath merge-base --is-ancestor $oid $bb 2>$null | Out-Null
+      if ($LASTEXITCODE -eq 0) {
+        return [pscustomobject]@{
+          PRNumber = $pr.number
+          Base = $base
+          MergeCommit = $oid
+          MergedAt = $pr.mergedAt
+        }
+      }
+    }
+
+    return $null
+  } catch {
+    return $null
+  }
+}
+
+$plan = New-Object System.Collections.Generic.List[object]
+
+foreach ($b in $candidates) {
+  $hasOpen = Get-HasOpenPR $b
+  $isAncestorMerged = Get-IsAncestorMerged $b
+  $mergedProof = $null
+  if ($AllowMergedPR -and ($hasOpen -ne $true)) {
+    $mergedProof = Get-MergedPRProof $b
+  }
+
+  $prOpenState = if ($hasOpen -eq $true) { "OPEN" } elseif ($hasOpen -eq $false) { "NONE" } else { "UNKNOWN" }
+  $mergedState = if ($isAncestorMerged) { "MERGED_ANCESTOR" } else { "NOT_ANCESTOR" }
+  $prMergedState = if ($mergedProof) { "MERGED_PR" } else { "NONE" }
+
+  $eligible = $false
+  $reason = New-Object System.Collections.Generic.List[string]
+
+  if ($hasOpen -eq $true) {
+    $eligible = $false
+    $reason.Add("pr_open") | Out-Null
+  } elseif ($hasOpen -eq $null -and -not $Force) {
+    $eligible = $false
+    $reason.Add("pr_unknown_no_gh") | Out-Null
+  }
+
+  if (-not $isAncestorMerged -and -not $Force) {
+    if ($AllowMergedPR) {
+      if ($mergedProof) {
+        # ok via squash-proof
+      } else {
+        $reason.Add("not_absorbed") | Out-Null
+      }
+    } else {
+      $reason.Add("not_absorbed") | Out-Null
+    }
+  }
+
+  if ($Force) {
+    if ($hasOpen -ne $true) {
+      $eligible = $true
+      if (-not $isAncestorMerged -and -not $mergedProof) { $reason.Add("force_unmerged") | Out-Null }
+      if ($hasOpen -eq $null) { $reason.Add("force_pr_unknown") | Out-Null }
+    } else {
+      $eligible = $false
+      $reason.Add("force_blocked_pr_open") | Out-Null
+    }
+  } else {
+    if (($hasOpen -eq $false) -and ($isAncestorMerged -or ($AllowMergedPR -and $mergedProof))) {
+      $eligible = $true
+      if ($isAncestorMerged) { $reason.Add("merged_no_pr") | Out-Null }
+      elseif ($mergedProof) { $reason.Add("merged_pr_proof") | Out-Null }
+    }
+  }
+
+  $plan.Add([pscustomobject]@{
+    Branch = $b
+    PR_Open = $prOpenState
+    Merged = $mergedState
+    PR_Merged_Proof = $prMergedState
+    PR_Number = $(if($mergedProof){$mergedProof.PRNumber}else{""})
+    PR_Base = $(if($mergedProof){$mergedProof.Base}else{""})
+    PR_MergeCommit = $(if($mergedProof){$mergedProof.MergeCommit}else{""})
+    Eligible = $eligible
+    Reason = ($reason -join ";")
+  })
+}
+
+# Relatorios
+$plan | Sort-Object Eligible,Branch | Export-Csv -NoTypeInformation -Encoding UTF8 -Path $csvPath
+
+$md = New-Object System.Text.StringBuilder
+$null = $md.AppendLine("# Plano de limpeza de branches remotos")
+$null = $md.AppendLine("")
+$null = $md.AppendLine("Repo: $RepoSlug")
+$null = $md.AppendLine("Mode: " + ($(if($Apply){"APPLY"} else {"DRYRUN"})))
+$null = $md.AppendLine("AllowMergedPR(squash): " + $AllowMergedPR.IsPresent)
+$null = $md.AppendLine("ReportDir: $reportDir")
+$null = $md.AppendLine("")
+$null = $md.AppendLine("| Branch | PR(Open) | Merged(Ancestor) | PR(Merged Proof) | Eligible | Reason |")
+$null = $md.AppendLine("|---|---|---|---|---:|---|")
+foreach ($r in ($plan | Sort-Object Eligible,Branch)) {
+  $null = $md.AppendLine("| $($r.Branch) | $($r.PR_Open) | $($r.Merged) | $($r.PR_Merged_Proof) | $($r.Eligible) | $($r.Reason) |")
+}
+$md.ToString() | Set-Content -LiteralPath $mdPath -Encoding UTF8
+
+Info "Report CSV: $csvPath"
+Info "Report MD : $mdPath"
+
+$toDelete = $plan | Where-Object { $_.Eligible -eq $true } | Select-Object -ExpandProperty Branch
+
+if (-not $toDelete -or $toDelete.Count -eq 0) {
+  Warn "Nenhum branch elegivel para delecao (pelas regras atuais)."
+  exit 0
+}
+
+if ($DryRun) {
+  Info "DryRun: branches elegiveis (nao deletados):"
+  $toDelete | ForEach-Object { Write-Host "  - $Remote/$_" }
+  exit 0
+}
+
+# APPLY
+Info "Deleting eligible branches on remote '$Remote'..."
+foreach ($b in $toDelete) {
+  try {
+    Info "Deleting: $Remote/$b"
+    git -C $RepoPath push $Remote --delete $b | Out-Null
+    try { git -C $RepoPath branch -dr "$Remote/$b" | Out-Null } catch {}
+  } catch {
+    Err ("Falhou ao deletar {0}/{1}: {2}" -f $Remote, $b, $_.Exception.Message)
+  }
+}
+
+Info "Done. Veja relatorios em: $reportDir"


### PR DESCRIPTION
Adds idempotent SQL lint fixes (duplicate index + function search_path) and the squash-aware remote branch prune helper script.

## Summary by Sourcery

Adicionar correções de lint para o banco de dados Supabase, guardrails de CI e workflows de varredura, além de ferramentas para limpeza segura de branches remotos e varredura de segredos.

Novas funcionalidades:
- Introduzir um helper em PowerShell, ciente de squash-merge, para planejar e limpar com segurança branches remotos elegíveis.
- Adicionar um helper em PowerShell para executar varreduras locais do gitleaks contra a árvore de trabalho.

Aprimoramentos:
- Tornar mais claro e robusto o guia do README do Supabase com configuração baseada em placeholders e regras de segurança para segredos.
- Estender o CI em Python para impor guardrails de runner, oferecer suporte a instalações tanto via pyproject quanto via requirements e, opcionalmente, executar verificações de guardas do repositório.
- Adicionar migração SQL opcional idempotente para remover índices/constraints redundantes e bloquear o `search_path` de funções para funções do Supabase.

Build:
- Adicionar um workflow de build-e-teste .NET que detecta automaticamente projetos .NET, executa testes, realiza verificações básicas de segurança e publica artefatos a partir da branch main.
- Adicionar workflow de varredura de segredos baseado em gitleaks para as branches main, develop e feature.

CI:
- Introduzir um job de guardrails para bloquear runners self-hosted e grandes antes dos testes, e modernizar as etapas de checkout e teste no workflow de CI existente.

Documentação:
- Atualizar o README do app Supabase para inglês, documentar a configuração segura do ambiente e fornecer exemplos para integração de autenticação e frontend.

Tarefas de manutenção:
- Adicionar dependência do Selenium ao arquivo de requirements do Python e adicionar arquivos de exemplo .env e CNAME com placeholders ao repositório.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Supabase database lint fixes, CI guardrails and scanning workflows, and tooling for safe remote branch pruning and secret scanning.

New Features:
- Introduce a squash-merge-aware PowerShell helper to plan and prune eligible remote branches safely.
- Add a PowerShell helper to run local gitleaks scans against the working tree.

Enhancements:
- Clarify and harden Supabase README guidance with placeholder-based configuration and security rules for secrets.
- Extend Python CI to enforce runner guardrails, support both pyproject and requirements installations, and optionally run repo guard checks.
- Add optional idempotent SQL migration to remove redundant index/constraints and lock function search_path for Supabase functions.

Build:
- Add a .NET build-and-test workflow that auto-detects .NET projects, runs tests, performs basic security checks, and publishes artifacts from main.
- Add gitleaks-based secret scanning workflow for main, develop, and feature branches.

CI:
- Introduce a guardrails job to block self-hosted and large runners before tests, and modernize checkout and test steps in the existing CI workflow.

Documentation:
- Update Supabase app README to English, document secure environment setup, and provide examples for auth and frontend integration.

Chores:
- Add Selenium dependency to the Python requirements file, and add placeholder .env example and CNAME files to the repo.

</details>